### PR TITLE
#13: 알림 엔티티 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'com.vladmihalcea:hibernate-types-60:2.19.0' // hibernate 에서 기본으로 제공해주는 데이터 타입들 외의 타입들을 추가해줌
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/project/sns/domain/CommentEntity.java
+++ b/src/main/java/com/project/sns/domain/CommentEntity.java
@@ -9,7 +9,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "comment")
+@Table(name = "comment",
+        indexes = {
+            @Index(name = "post_id_idx", columnList = "post_id")
+        }
+)
 public class CommentEntity {
 
     @Id

--- a/src/main/java/com/project/sns/domain/NotificationArgs.java
+++ b/src/main/java/com/project/sns/domain/NotificationArgs.java
@@ -1,0 +1,20 @@
+package com.project.sns.domain;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationArgs {
+
+    // 알람을 발생 시킨 사람 -> ex: 내 포스트에 좋아요를 누른 사람의 user_id
+    private Long fromUserId;
+
+    // 알림이 발생한 객체의 id -> ex: 내 포스트에 좋요요를 누르면, 해당 포스트의 post_id
+    private Long targetId;
+
+    public static NotificationArgs of(Long fromUserId, Long targetId) {
+        return new NotificationArgs(fromUserId, targetId);
+    }
+    
+}

--- a/src/main/java/com/project/sns/domain/NotificationEntity.java
+++ b/src/main/java/com/project/sns/domain/NotificationEntity.java
@@ -1,0 +1,87 @@
+package com.project.sns.domain;
+
+import com.project.sns.domain.enums.NotificationType;
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.Where;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE notification SET deleted_at = NOW() where id=?") // sql delete 가 일어날떄 deleted_at 값 업데이트
+@Where(clause = "deleted_at is NULL") // select 할때 해당 where 문도 추가되어서 실행 -> deleted_at 이 NULL 이면 삭제되지 않은 튜플들만 반환
+@Table(name = "notification",
+        indexes = {
+                @Index(name = "user_id_idx", columnList = "user_id")
+        }
+)
+public class NotificationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 알람을 받는 사람
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NotificationType notificationType;
+
+    /**
+     * NotificationArgs: 알림의 정보 저장 -> 알림을 발생 시킨 유저, 알림 타입, 알림을 일으킨 포스트/댓글 등등
+     *  => 추후에 파라미터들이 추가될 여지가 많음
+     *      => 그러므로, json 타입으로 DB에 저장
+     *          => MariaDB 에서 json 으로 컬럼을 매핑하기 위해서는 'longtext' 로 정의
+     */
+    @Type(JsonType.class)
+    @Column(columnDefinition = "longtext")
+    private NotificationArgs notificationArgs;
+
+    @Column(name = "registered_at")
+    private Timestamp registeredAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "deleted_at")
+    private Timestamp deletedAt;
+
+    @PrePersist
+    void registeredAt() {
+        this.registeredAt = Timestamp.from(Instant.now());
+    }
+
+    @PreUpdate
+    void updatedAt() {
+        this.updatedAt = Timestamp.from(Instant.now());
+    }
+
+    public static NotificationEntity of(UserEntity userEntity, NotificationType notificationType, NotificationArgs notificationArgs) {
+        return NotificationEntity.of(null, userEntity, notificationType, notificationArgs, null, null, null);
+    }
+
+    public static NotificationEntity of(Long id, UserEntity userEntity, NotificationType notificationType, NotificationArgs notificationArgs, Timestamp registeredAt, Timestamp updatedAt, Timestamp deletedAt) {
+        return new NotificationEntity(
+                id,
+                userEntity,
+                notificationType,
+                notificationArgs,
+                registeredAt,
+                updatedAt,
+                deletedAt
+        );
+    }
+}

--- a/src/main/java/com/project/sns/domain/PostEntity.java
+++ b/src/main/java/com/project/sns/domain/PostEntity.java
@@ -18,7 +18,11 @@ import java.time.Instant;
 @AllArgsConstructor
 @SQLDelete(sql = "UPDATE post SET deleted_at = NOW() where id=?") // sql delete 가 일어날떄 deleted_at 값 업데이트
 @Where(clause = "deleted_at is NULL") // select 할때 해당 where 문도 추가되어서 실행 -> deleted_at 이 NULL 이면 삭제되지 않은 튜플들만 반환
-@Table(name = "post")
+@Table(name = "post",
+    indexes = {
+        @Index(name = "user_id_idx", columnList = "user_id")
+    }
+)
 public class PostEntity {
 
     @Id
@@ -32,7 +36,7 @@ public class PostEntity {
     private String body;
 
     @ManyToOne
-    @JoinColumn(name = "userId")
+    @JoinColumn(name = "user_id")
     private UserEntity userEntity;
 
     @Column(name = "registered_at")

--- a/src/main/java/com/project/sns/domain/UpVoteEntity.java
+++ b/src/main/java/com/project/sns/domain/UpVoteEntity.java
@@ -8,7 +8,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "upvote")
+@Table(name = "upvote",
+    indexes = {
+        @Index(name = "post_id_idx", columnList = "post_id")
+    }
+)
 public class UpVoteEntity {
 
     @Id

--- a/src/main/java/com/project/sns/domain/UserEntity.java
+++ b/src/main/java/com/project/sns/domain/UserEntity.java
@@ -58,6 +58,10 @@ public class UserEntity {
         return UserEntity.of(null, username, password, null, null, null, null);
     }
 
+    public static UserEntity of(Long id, String username, String password) {
+        return UserEntity.of(id, username, password, null, null, null, null);
+    }
+
     public static UserEntity of(String username, String password, UserRole userRole) {
         return UserEntity.of(null, username, password, userRole, null, null, null);
     }

--- a/src/test/java/com/project/sns/repository/UpVoteEntityRepositoryTest.java
+++ b/src/test/java/com/project/sns/repository/UpVoteEntityRepositoryTest.java
@@ -34,9 +34,9 @@ class UpVoteEntityRepositoryTest {
     @Test
     void givenTestData_whenCallingFindByPostEntityAndUpVoted_thenSuccess() throws Exception {
         // Given
-        UserEntity userA = UserEntity.of("usernameA", "password");
-        UserEntity userB = UserEntity.of("usernameB", "password");
-        UserEntity userC = UserEntity.of("usernameC", "password");
+        UserEntity userA = UserEntity.of(1L, "usernameA", "password");
+        UserEntity userB = UserEntity.of(2L, "usernameB", "password");
+        UserEntity userC = UserEntity.of(3L, "usernameC", "password");
         PostEntity post = PostEntity.of("title", "body", userA);
 
         UpVoteEntity upVoteA = UpVoteEntity.of(userA, post, true);


### PR DESCRIPTION
* 알림 엔티티 정의(NotificationEntity)
* NotificationEntity 중 하나의 파라미터는 NotificationArgs 로 저장
* NotificationArgs는 엔티티가 아니고, 일반 클래스-> 그러므로, 연관 관계 없이 컬럼을 json으로 정의해서 저장
* Json으로 정의 해서,NotificationEntity에 넣고 싶은 파라미터가 추가될때,NotificationArgs만 수정하면 됨->확정성이 매우 높음
     * https://github.com/vladmihalcea/hypersistence-utils
     * https://danawalab.github.io/spring/2022/08/05/Jpa-Json-Type.html
     * com.vladmihalcea:hibernate-types
     * @Type(JsonType.class) && @Column(columnDefinition = "longtext") 으로 정의해서, NotificationArgs가 자동으로 json 변환되고, 컬럼도 json 으로 저장 (MariaDB는 json 정의시, 'longtext' 로 선언 (PostrgreSql 은 'json')
* 그 외 minor refactoring 
