### PR TITLE
#13: 댓글 작성 또는 좋아요 누를 수, 포스트 작성자에게  알림 생성 및 유저 알림 가져오기 구현

### DIFF
--- a/src/main/java/com/project/sns/controller/UserController.java
+++ b/src/main/java/com/project/sns/controller/UserController.java
@@ -3,16 +3,17 @@ package com.project.sns.controller;
 import com.project.sns.domain.UserEntity;
 import com.project.sns.dto.request.UserJoinRequest;
 import com.project.sns.dto.request.UserLoginRequest;
+import com.project.sns.dto.response.NotificationResponse;
 import com.project.sns.dto.response.ResponseBody;
 import com.project.sns.dto.response.UserJoinResponse;
 import com.project.sns.dto.response.UserLoginResponse;
 import com.project.sns.service.UserEntityService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,4 +35,13 @@ public class UserController {
 
         return ResponseBody.success("OK", UserLoginResponse.of(token));
     }
+
+    @GetMapping("/notifications")
+    public ResponseBody<Page<NotificationResponse>> fetchNotifications(Pageable pageable, Authentication authentication) {
+        Page<NotificationResponse> notifications = userEntityService.fetchNotifications(pageable, authentication.getName())
+                .map(NotificationResponse::fromDto);
+
+        return ResponseBody.success("Success", notifications);
+    }
+
 }

--- a/src/main/java/com/project/sns/domain/UpVoteEntity.java
+++ b/src/main/java/com/project/sns/domain/UpVoteEntity.java
@@ -3,8 +3,10 @@ package com.project.sns.domain;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/project/sns/domain/enums/NotificationType.java
+++ b/src/main/java/com/project/sns/domain/enums/NotificationType.java
@@ -1,0 +1,14 @@
+package com.project.sns.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+    NEW_LIKE_ON_POST("New Like."), NEW_COMMENT_ON_POST("New Comment.");
+
+    private String notificationMessage;
+
+    NotificationType(String notificationMessage) {
+        this.notificationMessage = notificationMessage;
+    }
+}

--- a/src/main/java/com/project/sns/dto/entity/NotificationDto.java
+++ b/src/main/java/com/project/sns/dto/entity/NotificationDto.java
@@ -1,0 +1,42 @@
+package com.project.sns.dto.entity;
+
+import com.project.sns.domain.NotificationArgs;
+import com.project.sns.domain.NotificationEntity;
+import com.project.sns.domain.UserEntity;
+import com.project.sns.domain.enums.NotificationType;
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationDto {
+
+    private Long id;
+    private UserDto user;
+    private NotificationType notificationType;
+    private NotificationArgs notificationArgs;
+    private Timestamp registeredAt;
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+
+    public static NotificationDto fromEntity(NotificationEntity entity) {
+        return new NotificationDto(
+                entity.getId(),
+                entity.getUserEntity().toDto(),
+                entity.getNotificationType(),
+                entity.getNotificationArgs(),
+                entity.getRegisteredAt(),
+                entity.getUpdatedAt(),
+                entity.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/project/sns/dto/response/NotificationResponse.java
+++ b/src/main/java/com/project/sns/dto/response/NotificationResponse.java
@@ -1,0 +1,39 @@
+package com.project.sns.dto.response;
+
+import com.project.sns.domain.NotificationArgs;
+import com.project.sns.domain.enums.NotificationType;
+import com.project.sns.dto.entity.NotificationDto;
+import com.project.sns.dto.entity.UserDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+
+    private Long id;
+    private NotificationType notificationType;
+    private NotificationArgs notificationArgs;
+    private String message;
+    private Timestamp registeredAt;
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+
+    public static NotificationResponse fromDto(NotificationDto dto) {
+        return new NotificationResponse(
+                dto.getId(),
+                dto.getNotificationType(),
+                dto.getNotificationArgs(),
+                dto.getNotificationType().getNotificationMessage(),
+                dto.getRegisteredAt(),
+                dto.getUpdatedAt(),
+                dto.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/project/sns/repository/NotificationEntityRepository.java
+++ b/src/main/java/com/project/sns/repository/NotificationEntityRepository.java
@@ -1,0 +1,12 @@
+package com.project.sns.repository;
+
+import com.project.sns.domain.NotificationEntity;
+import com.project.sns.domain.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationEntityRepository extends JpaRepository<NotificationEntity, Long> {
+
+    Page<NotificationEntity> findAllByUserEntity(UserEntity userEntity, Pageable pageable);
+}

--- a/src/test/java/com/project/sns/service/PostServiceTest.java
+++ b/src/test/java/com/project/sns/service/PostServiceTest.java
@@ -1,16 +1,12 @@
 package com.project.sns.service;
 
-import com.project.sns.domain.CommentEntity;
-import com.project.sns.domain.PostEntity;
-import com.project.sns.domain.UserEntity;
+import com.project.sns.domain.*;
+import com.project.sns.domain.enums.NotificationType;
 import com.project.sns.domain.enums.UserRole;
 import com.project.sns.dto.request.CommentCreateRequest;
 import com.project.sns.exception.SnsApplicationException;
 import com.project.sns.exception.enums.ErrorCode;
-import com.project.sns.repository.CommentEntityRepository;
-import com.project.sns.repository.PostRepository;
-import com.project.sns.repository.UpVoteEntityRepository;
-import com.project.sns.repository.UserEntityRepository;
+import com.project.sns.repository.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,6 +42,9 @@ class PostServiceTest {
 
     @MockBean
     private CommentEntityRepository commentEntityRepository;
+
+    @MockBean
+    private NotificationEntityRepository notificationEntityRepository;
 
     @DisplayName("[Service][Post] Given Parameters - When Creating Post - Success")
     @Test
@@ -220,10 +219,13 @@ class PostServiceTest {
         Optional<UserEntity> optionalUserEntity = createOptionalUserEntity(username);
         PostEntity postEntity = createPostEntity(postId, "title", "body", optionalUserEntity.get());
 
-
         given(userEntityRepository.findByUsername(any())).willReturn(optionalUserEntity);
         given(postRepository.findById(any())).willReturn(Optional.of(postEntity));
         given(commentEntityRepository.save(any())).willReturn(CommentEntity.of("comment", optionalUserEntity.get(), postEntity));
+        given(notificationEntityRepository.save(any()))
+                .willReturn(NotificationEntity.of(
+                        optionalUserEntity.get(), NotificationType.NEW_COMMENT_ON_POST, NotificationArgs.of(1L, 1L)
+                ));
 
         // When && Then
         Assertions.assertDoesNotThrow(() -> postService.addComment(request, postId, username));
@@ -231,6 +233,7 @@ class PostServiceTest {
         then(userEntityRepository).should().findByUsername(any());
         then(postRepository).should().findById(any());
         then(commentEntityRepository).should().save(any());
+        then(notificationEntityRepository).should().save(any());
     }
 
     private static CommentCreateRequest createCommentCreateRequest(String comment) {


### PR DESCRIPTION
* 유저 알림 조회하기 구현
* 포스트에 댓글 작성 시, 포스트 작성자에게 알림 생성
     * 댓글 작성자랑 포스트 작성자가 다를 경우에만 생성 
     * 알림에 댓글 작성자 & 포스트 아이디 저장(NotificationArgs)
* 포스트에 좋아요 누를 시, 포스트 작성자에게 알림 생성
     * 좋아요 누른 유저와 포스트 작성자가 다를 경우에만 생성 
     * 알림에 좋아요 누른 작성자 & 포스트 아이디 저장(NotificationArgs)