### PR TITLE
#23: 쿼리 최적화

### DIFF
--- a/src/main/java/com/project/sns/controller/UserController.java
+++ b/src/main/java/com/project/sns/controller/UserController.java
@@ -1,13 +1,17 @@
 package com.project.sns.controller;
 
 import com.project.sns.domain.UserEntity;
+import com.project.sns.dto.entity.UserDto;
 import com.project.sns.dto.request.UserJoinRequest;
 import com.project.sns.dto.request.UserLoginRequest;
 import com.project.sns.dto.response.NotificationResponse;
 import com.project.sns.dto.response.ResponseBody;
 import com.project.sns.dto.response.UserJoinResponse;
 import com.project.sns.dto.response.UserLoginResponse;
+import com.project.sns.exception.SnsApplicationException;
+import com.project.sns.exception.enums.ErrorCode;
 import com.project.sns.service.UserEntityService;
+import com.project.sns.util.ClassUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,7 +42,9 @@ public class UserController {
 
     @GetMapping("/notifications")
     public ResponseBody<Page<NotificationResponse>> fetchNotifications(Pageable pageable, Authentication authentication) {
-        Page<NotificationResponse> notifications = userEntityService.fetchNotifications(pageable, authentication.getName())
+        UserDto userDto = ClassUtils.getSafeCastInstance(authentication.getPrincipal(), UserDto.class);
+
+        Page<NotificationResponse> notifications = userEntityService.fetchNotifications(pageable, userDto.getId())
                 .map(NotificationResponse::fromDto);
 
         return ResponseBody.success("Success", notifications);

--- a/src/main/java/com/project/sns/domain/NotificationEntity.java
+++ b/src/main/java/com/project/sns/domain/NotificationEntity.java
@@ -32,7 +32,7 @@ public class NotificationEntity {
     private Long id;
 
     // 알람을 받는 사람
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity userEntity;
 

--- a/src/main/java/com/project/sns/domain/PostEntity.java
+++ b/src/main/java/com/project/sns/domain/PostEntity.java
@@ -35,7 +35,7 @@ public class PostEntity {
     @Column(nullable = false)
     private String body;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity userEntity;
 

--- a/src/main/java/com/project/sns/dto/entity/NotificationDto.java
+++ b/src/main/java/com/project/sns/dto/entity/NotificationDto.java
@@ -10,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.Type;
 
 import java.sql.Timestamp;
 
@@ -21,7 +20,6 @@ import java.sql.Timestamp;
 public class NotificationDto {
 
     private Long id;
-    private UserDto user;
     private NotificationType notificationType;
     private NotificationArgs notificationArgs;
     private Timestamp registeredAt;
@@ -31,7 +29,6 @@ public class NotificationDto {
     public static NotificationDto fromEntity(NotificationEntity entity) {
         return new NotificationDto(
                 entity.getId(),
-                entity.getUserEntity().toDto(),
                 entity.getNotificationType(),
                 entity.getNotificationArgs(),
                 entity.getRegisteredAt(),

--- a/src/main/java/com/project/sns/repository/CommentEntityRepository.java
+++ b/src/main/java/com/project/sns/repository/CommentEntityRepository.java
@@ -5,10 +5,16 @@ import com.project.sns.domain.PostEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CommentEntityRepository extends JpaRepository<CommentEntity, Long> {
 
     Page<CommentEntity> findAllByPostEntity(PostEntity postEntity, Pageable pageable);
+
+    @Modifying // Queries that require a `@Modifying` annotation include INSERT, UPDATE, DELETE, and DDL statements.
+    @Query("DELETE FROM CommentEntity c WHERE c.postEntity = :postEntity")
+    void deleteAllByPostEntity(PostEntity postEntity);
 }

--- a/src/main/java/com/project/sns/repository/NotificationEntityRepository.java
+++ b/src/main/java/com/project/sns/repository/NotificationEntityRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationEntityRepository extends JpaRepository<NotificationEntity, Long> {
 
-    Page<NotificationEntity> findAllByUserEntity(UserEntity userEntity, Pageable pageable);
+    Page<NotificationEntity> findAllByUserEntityId(Long userEntityId, Pageable pageable);
 }

--- a/src/main/java/com/project/sns/repository/UpVoteEntityRepository.java
+++ b/src/main/java/com/project/sns/repository/UpVoteEntityRepository.java
@@ -4,6 +4,7 @@ import com.project.sns.domain.PostEntity;
 import com.project.sns.domain.UpVoteEntity;
 import com.project.sns.domain.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -14,4 +15,8 @@ public interface UpVoteEntityRepository extends JpaRepository<UpVoteEntity, Long
 
     @Query("SELECT COUNT(*) FROM UpVoteEntity u WHERE u.postEntity=:postEntity AND u.upVoted=:upVoted")
     Long findByPostEntityAndUpVoted(PostEntity postEntity, boolean upVoted);
+
+    @Modifying // Queries that require a `@Modifying` annotation include INSERT, UPDATE, DELETE, and DDL statements.
+    @Query("DELETE FROM UpVoteEntity u WHERE u.postEntity = :postEntity")
+    void deleteAllByPostEntity(PostEntity postEntity);
 }

--- a/src/main/java/com/project/sns/service/PostService.java
+++ b/src/main/java/com/project/sns/service/PostService.java
@@ -88,6 +88,12 @@ public class PostService {
         if(userDoesNotMatch(userName, post)){
             throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION, "User does not match.");
         }
+        
+        // Post랑 연관된 UpVote 삭제
+        upVoteEntityRepository.deleteAllByPostEntity(post);
+        
+        // Post랑 연관된 Comment 삭제
+        commentEntityRepository.deleteAllByPostEntity(post);
 
         // Post 삭제
         postRepository.delete(post);

--- a/src/main/java/com/project/sns/service/UserEntityService.java
+++ b/src/main/java/com/project/sns/service/UserEntityService.java
@@ -89,11 +89,9 @@ public class UserEntityService {
         return (username == null || username.isBlank() || password == null || password.isBlank());
     }
 
-    public Page<NotificationDto> fetchNotifications(Pageable pageable, String userName) {
-        // User 가 존재하는지 확인
-        UserEntity userEntity = getUserEntityOrThrowException(userName);
+    public Page<NotificationDto> fetchNotifications(Pageable pageable, Long userId) {
 
-        return notificationEntityRepository.findAllByUserEntity(userEntity, pageable)
+        return notificationEntityRepository.findAllByUserEntityId(userId, pageable)
                 .map(NotificationDto::fromEntity);
     }
 

--- a/src/main/java/com/project/sns/util/ClassUtils.java
+++ b/src/main/java/com/project/sns/util/ClassUtils.java
@@ -1,0 +1,10 @@
+package com.project.sns.util;
+
+import java.util.Optional;
+
+public class ClassUtils {
+
+    public static <T>  T getSafeCastInstance(Object o, Class<T> clazz){
+        return clazz != null && clazz.isInstance(o) ? clazz.cast(o) : null;
+    }
+}


### PR DESCRIPTION
* 알림 가져올 때, DB에 쿼리를 처리하는 횟수 감소
     - 이미 인증 과정에서  principal에 유저 정보가 있기 때문에, 해당 유저의 존재 유무를 다시 파악할 필요 X
     - 이미 인증 과정에서 유저의 존재 유무를 파악함
     - Authentication의 principal은 UserDto가 저장됨 -> 현재 유저 정보를 알고 싶으면 Authentication의 principal을 가져오면 됨
     - 가져올때, 안전하게 Type Casting을 하기 위한 메서도 생성(ClassUtils.getSafeCastInstance())
 * (N+1 해결) 데이터 전달 X + fetchType 설정
 * Delete 쿼리 직접 작성
      - JPA에서 제공하는 delete()/deleteAll() 메서드 사용은 비효율적
     - 해당 메서드들은, 삭제할 튜플이 저장된 테이블을 전체 조회한 후 해당 튜플들 삭제 -> 쿼리가 2번 처리됨(select , delete 각각 한번씩)